### PR TITLE
Update vit.py

### DIFF
--- a/Extension/.gitignore
+++ b/Extension/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 config_ali.yml
+.gitignore

--- a/Extension/src/nodes/vit.py
+++ b/Extension/src/nodes/vit.py
@@ -183,8 +183,6 @@ class VisionTransformerLearnerNode:
         label_enc = kutil.LabelEncoder()
         train_labels_encoded = label_enc.fit_transform(train_labels)
         val_labels_encoded = label_enc.transform(val_labels)
-        
-        LOGGER.warn(self.model_choice)
 
         # Model selection logic
         if self.model_choice == mutil.ViTModelSelection.ViT.name:
@@ -433,10 +431,8 @@ class VisionTransformerPredictor:
 
         features = df_test[image_col]
 
-        LOGGER.warning(image_col[0])
-
         images = features[image_col[0]]
-        
+
         model_name = model_port.spec.model_choice
 
         if model_name == mutil.ViTModelSelection.ViT.name:

--- a/Extension/src/nodes/vit.py
+++ b/Extension/src/nodes/vit.py
@@ -50,11 +50,33 @@ image_category = knext.category(
 )
 class VisionTransformerLearnerNode:
     """
+    Vision Transformer Learner
 
-    Learner node
+    Learns an image classification model using a Vision Transformer (ViT) architecture, implemented by the 
+    [Hugging Face Transformers](https://huggingface.co/docs/transformers/index) library.
+    It is a deep learning model that processes image data by dividing it into patches and applying transformer-based 
+    self-attention mechanisms.
 
+    The model is trained using a selected image column and label column from the input training dataset. Users can 
+    choose from multiple Vision Transformer architectures, including ViT, Swin Transformer, and Pyramid Transformer. 
+    Training parameters such as batch size, number of epochs, and learning rate can be customized. The node outputs 
+    a trained Vision Transformer model that can be used for image classification with the Transformer Predictor node.
+
+    Models:
+    - **Vision Transformer (ViT)**: A transformer-based model for image classification that treats images as sequences of 
+      patches and applies self-attention mechanisms. 
+      [More info](https://huggingface.co/docs/transformers/model_doc/vit)
+
+    - **Swin Transformer**: A hierarchical transformer model with shifted window attention, designed for high-resolution 
+      image classification and dense prediction tasks.
+      [More info](https://huggingface.co/docs/transformers/model_doc/swin)
+
+    - **Pyramid Vision Transformer (PVT)**: A transformer model that incorporates a pyramid structure with progressively 
+      shrinking patch sizes, making it efficient for tasks like object detection and segmentation.
+      [More info](https://huggingface.co/docs/transformers/model_doc/pvt)
 
     """
+
 
     image_column = knext.ColumnParameter(
         label="Image Column",
@@ -377,6 +399,20 @@ class ClassificationPredictorGeneralSettings:
     name="Output table", description="Resulting table with prediction categories."
 )
 class VisionTransformerPredictor:
+
+    """
+    Vision Transformer Predictor   
+
+    The Vision Transformer Predictor Node applies a trained Vision Transformer model to classify images in the given input dataset.
+    It computes the predicted class for each image and, optionally, provides class probability estimates.
+
+    The node requires a trained Transformer model from the Transformer Learner Node and a dataset containing image data.
+    The prediction column name can be customized, and the node supports multiple Transformer architectures.
+    
+    It is only executable if the test data contains the image column that was used by the learner model.
+    
+    """
+
 
     predictor_settings = ClassificationPredictorGeneralSettings()
 

--- a/Extension/src/nodes/vit.py
+++ b/Extension/src/nodes/vit.py
@@ -51,36 +51,31 @@ image_category = knext.category(
 class VisionTransformerLearnerNode:
     """
     Vision Transformer Learner Node
-    ========================================
 
-    The Vision Transformer Learner node enables users to fine-tune transformer-based models. 
-    It is a deep learning model that processes image data by dividing it into patches and applying transformer-based 
+    The Vision Transformer Learner node enables users to fine-tune transformer-based models.
+    It is a deep learning model that processes image data by dividing it into patches and applying transformer-based
     self-attention mechanisms.
 
-    The model is fine-tuned using a selected image column and label column from the input training dataset. Users can 
-    choose from multiple Transformer architectures, including ViT, Swin Transformer, and Pyramid Transformer. 
-    Training parameters such as batch size, number of epochs, and learning rate can be customized. After the fine-tunig part, the node takes as input the validation set, 
+    The model is fine-tuned using a selected image column and label column from the input training dataset. Users can
+    choose from multiple Transformer architectures, including ViT, Swin Transformer, and Pyramid Transformer.
+    Training parameters such as batch size, number of epochs, and learning rate can be customized. After the fine-tunig part, the node takes as input the validation set,
     which is helpful to find the best parameters of the model.
     The node outputs a fine-tuned model that can be used for image classification with the Transformer Predictor node.
-    
+
     This node supports fine-tuning of three different models' architectures:
 
 
-    - **Vision Transformer (ViT)**: A transformer-based model for image classification that treats images as sequences of 
-      patches and applies self-attention mechanisms. 
+    - **Vision Transformer (ViT)**: A transformer-based model for image classification that treats images as sequences of
+      patches and applies self-attention mechanisms.
       [More info](https://huggingface.co/docs/transformers/model_doc/vit)
 
-    - **Swin Transformer**: A hierarchical transformer model with shifted window attention, designed for high-resolution 
+    - **Swin Transformer**: A hierarchical transformer model with shifted window attention, designed for high-resolution
       image classification and dense prediction tasks.
       [More info](https://huggingface.co/docs/transformers/model_doc/swin)
 
-    - **Pyramid Vision Transformer (PVT)**: A transformer model that incorporates a pyramid structure with progressively 
+    - **Pyramid Vision Transformer (PVT)**: A transformer model that incorporates a pyramid structure with progressively
       shrinking patch sizes, making it efficient for tasks like object detection and segmentation.
       [More info](https://huggingface.co/docs/transformers/model_doc/pvt)
-
-
-
-    ========================================
 
 
 
@@ -112,13 +107,12 @@ class VisionTransformerLearnerNode:
     4. Training runs for the specified number of epochs, tracking performance metrics.
     5. The trained model and a performance summary table are returned as outputs.
 
-    This node is ideal for users who want to fine-tune transformer models for image classification tasks without 
-    writing complex deep-learning code. It integrates seamlessly into KNIME's analytics workflow, providing a 
+    This node is ideal for users who want to fine-tune transformer models for image classification tasks without
+    writing complex deep-learning code. It integrates seamlessly into KNIME's analytics workflow, providing a
     user-friendly interface for powerful model training.
 
 
     """
-
 
     image_column = knext.ColumnParameter(
         label="Image Column",
@@ -441,22 +435,18 @@ class ClassificationPredictorGeneralSettings:
     name="Output table", description="Resulting table with prediction categories."
 )
 class VisionTransformerPredictor:
-
     """
-    Vision Transformer Predictor   
+    Vision Transformer Predictor
 
-    ========================================
 
     The Vision Transformer Predictor Node applies a fine-tuned Transformer model to classify images in the given input dataset.
     It computes the predicted class for each image and, optionally, provides class probability estimates.
 
     The node requires a fine-tuned Transformer model from the Vision Transformer Learner Node and a dataset containing image data.
     The prediction column name can be customized, and the node supports multiple Transformer architectures.
-    
+
     It is only executable if the test data contains the image column that was used by the learner model.
 
-
-    ========================================
 
 
     ### Input Requirements:
@@ -482,9 +472,8 @@ class VisionTransformerPredictor:
     3. The highest probability class is assigned as the predicted label.
     4. (Optional) Class probability estimates are computed using softmax and included in the output.
 
-    
-    """
 
+    """
 
     predictor_settings = ClassificationPredictorGeneralSettings()
 

--- a/Extension/src/nodes/vit.py
+++ b/Extension/src/nodes/vit.py
@@ -50,19 +50,22 @@ image_category = knext.category(
 )
 class VisionTransformerLearnerNode:
     """
-    Vision Transformer Learner
+    Vision Transformer Learner Node
+    ========================================
 
-    Learns an image classification model using a Vision Transformer (ViT) architecture, implemented by the 
-    [Hugging Face Transformers](https://huggingface.co/docs/transformers/index) library.
+    The Vision Transformer Learner node enables users to fine-tune transformer-based models. 
     It is a deep learning model that processes image data by dividing it into patches and applying transformer-based 
     self-attention mechanisms.
 
-    The model is trained using a selected image column and label column from the input training dataset. Users can 
-    choose from multiple Vision Transformer architectures, including ViT, Swin Transformer, and Pyramid Transformer. 
-    Training parameters such as batch size, number of epochs, and learning rate can be customized. The node outputs 
-    a trained Vision Transformer model that can be used for image classification with the Transformer Predictor node.
+    The model is fine-tuned using a selected image column and label column from the input training dataset. Users can 
+    choose from multiple Transformer architectures, including ViT, Swin Transformer, and Pyramid Transformer. 
+    Training parameters such as batch size, number of epochs, and learning rate can be customized. After the fine-tunig part, the node takes as input the validation set, 
+    which is helpful to find the best parameters of the model.
+    The node outputs a fine-tuned model that can be used for image classification with the Transformer Predictor node.
+    
+    This node supports fine-tuning of three different models' architectures:
 
-    Models:
+
     - **Vision Transformer (ViT)**: A transformer-based model for image classification that treats images as sequences of 
       patches and applies self-attention mechanisms. 
       [More info](https://huggingface.co/docs/transformers/model_doc/vit)
@@ -74,6 +77,45 @@ class VisionTransformerLearnerNode:
     - **Pyramid Vision Transformer (PVT)**: A transformer model that incorporates a pyramid structure with progressively 
       shrinking patch sizes, making it efficient for tasks like object detection and segmentation.
       [More info](https://huggingface.co/docs/transformers/model_doc/pvt)
+
+
+
+    ========================================
+
+
+
+    ### Input Requirements:
+    - **Training Data**: A table containing images and corresponding labels for training the model.
+    - **Validation Data**: A table containing images and labels for validating model performance.
+
+    ### Configuration Options:
+    - **Image Column**: Select the column containing image data (must be in PNG format).
+    - **Label Column**: Select the target column containing class labels.
+    - **Number of Epochs**: Defines the number of iterations over the dataset.
+    - **Batch Size**: Determines the number of images processed in each training step.
+    - **Learning Rate**: Sets the optimizer's step size for updating model weights.
+    - **Model Choice**: Choose between ViT, Swin Transformer, or Pyramid Transformer.
+
+    ### Output:
+    - **Fine-tuned Model**: A fully fine-tuned transformer model that can be used for inference.
+    - **Training Summary Table**: A table displaying key training statistics:
+    - Epoch count
+    - Training loss
+    - Training accuracy
+    - Validation loss
+    - Validation accuracy
+
+    ### How It Works:
+    1. The node processes images and encodes labels.
+    2. The selected transformer model is initialized and fine-tuned using the provided training data.
+    3. A loss function (Cross-Entropy Loss) and optimizer (Adam) are applied to optimize model performance.
+    4. Training runs for the specified number of epochs, tracking performance metrics.
+    5. The trained model and a performance summary table are returned as outputs.
+
+    This node is ideal for users who want to fine-tune transformer models for image classification tasks without 
+    writing complex deep-learning code. It integrates seamlessly into KNIME's analytics workflow, providing a 
+    user-friendly interface for powerful model training.
+
 
     """
 
@@ -403,13 +445,43 @@ class VisionTransformerPredictor:
     """
     Vision Transformer Predictor   
 
-    The Vision Transformer Predictor Node applies a trained Vision Transformer model to classify images in the given input dataset.
+    ========================================
+
+    The Vision Transformer Predictor Node applies a fine-tuned Transformer model to classify images in the given input dataset.
     It computes the predicted class for each image and, optionally, provides class probability estimates.
 
-    The node requires a trained Transformer model from the Transformer Learner Node and a dataset containing image data.
+    The node requires a fine-tuned Transformer model from the Vision Transformer Learner Node and a dataset containing image data.
     The prediction column name can be customized, and the node supports multiple Transformer architectures.
     
     It is only executable if the test data contains the image column that was used by the learner model.
+
+
+    ========================================
+
+
+    ### Input Requirements:
+
+    - **Trained Model**: A ViT model trained using the ViT Classification Learner node.
+    - **Test Input Data**: A table containing image data for classification.
+
+    ### Configuration Options:
+
+    - **Custom Prediction Column Name**: Specify a custom name for the prediction column.
+    - **Predict Probability Estimates**: Enable to obtain confidence scores for each class.
+    - **Probability Columns Suffix**: Add a suffix to probability columns for easy identification.
+
+    ### Output:
+
+    - **Predicted Labels Table**: A table containing image predictions with the assigned class label.
+    - **Class Probability Estimates (Optional)**: If enabled, displays confidence scores for each class.
+
+    ### How It Works:
+
+    1. The node extracts images from the test dataset.
+    2. The selected transformer model processes the images and makes predictions.
+    3. The highest probability class is assigned as the predicted label.
+    4. (Optional) Class probability estimates are computed using softmax and included in the output.
+
     
     """
 

--- a/Extension/src/nodes/vit.py
+++ b/Extension/src/nodes/vit.py
@@ -186,7 +186,6 @@ class VisionTransformerLearnerNode:
         
         LOGGER.warn(self.model_choice)
 
-
         # Model selection logic
         if self.model_choice == mutil.ViTModelSelection.ViT.name:
             processor = ViTImageProcessor.from_pretrained(
@@ -259,7 +258,9 @@ class VisionTransformerLearnerNode:
         # Model setup
         model.config.num_labels = num_classes
         if self.model_choice == mutil.ViTModelSelection.PYRAMID.name:
-            model.classifier = torch.nn.Linear(model.config.hidden_sizes[-1], num_classes)
+            model.classifier = torch.nn.Linear(
+                model.config.hidden_sizes[-1], num_classes
+            )
         else:
             model.classifier = torch.nn.Linear(model.config.hidden_size, num_classes)
         criterion = torch.nn.CrossEntropyLoss()

--- a/Extension/src/utils/modeling_utils.py
+++ b/Extension/src/utils/modeling_utils.py
@@ -50,7 +50,7 @@ class ViTModelSelection(kutil.knext.EnumParameterOptions):
     )
     PYRAMID = (
         "Pyramid Transformer",
-        "Zetatech/pvt-medium-224.",
+        "Zetatech/pvt-medium-224",
     )
 
     @classmethod


### PR DESCRIPTION
Added description for both learner and predictor node. In the Learner nodes there's a short description and the corresponding link for every model. I used as example the knime sklearn link (https://github.com/knime/knime-python-sklearn/tree/master)